### PR TITLE
feat: require api key in posts controller

### DIFF
--- a/app/controllers/api/authenticated_base_controller.rb
+++ b/app/controllers/api/authenticated_base_controller.rb
@@ -1,0 +1,5 @@
+module Api
+  class AuthenticatedBaseController < ApplicationController
+    include ApiKeyAuthenticable
+  end
+end

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class PostsController < ApplicationController
+  class PostsController < AuthenticatedBaseController
     include FindableResource
     include Paginatable
 

--- a/app/controllers/concerns/api_key_authenticable.rb
+++ b/app/controllers/concerns/api_key_authenticable.rb
@@ -1,0 +1,34 @@
+# controllers that will use this module should have a payload method
+module ApiKeyAuthenticable
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authenticate_api_key, :set_user_from_api_key
+    attr_reader :api_key, :user
+  end
+
+  private
+
+  def authenticate_api_key
+    @api_key = request.headers['FACEBOOK-API-KEY']
+
+    return payload(errors: ["API key is missing"], status: :unauthorized) unless @api_key
+
+    payload(errors: ["Invalid API key"], status: :unauthorized) unless valid_api_key?
+  end
+
+  def set_user_from_api_key
+    @user = User.find_by(id: decoded_token_user_id)
+  end
+
+  def valid_api_key?
+    user_id = decoded_token_user_id
+    user_id && User.exists?(id: user_id)
+  end
+
+  def decoded_token_user_id
+    decoded_token = JwtLoginToken.decode(@api_key)
+    decoded_token.present? ? decoded_token[0]["user_id"] : nil
+  end
+
+end

--- a/lib/jwt_login_token.rb
+++ b/lib/jwt_login_token.rb
@@ -12,7 +12,8 @@ class JwtLoginToken
   def self.decode(token)
     begin
       decoded_data = JWT.decode(token, SECRET_KEY, true, algorithm: ALGORITHM)
-    rescue JWT::ExpiredSignature
+    rescue JWT::ExpiredSignature, JWT::VerificationError
+      # TODO: send to remote logger
       false
     end
   end


### PR DESCRIPTION
This PR requires posts controller requests to have valid `FACEBOOK-API-KEY`.

### With valid API Key
![image](https://github.com/user-attachments/assets/9eb9b0cb-ba58-4a46-b223-116a98963d4d)

### Missing API Key Error (when there is no api key)
![image](https://github.com/user-attachments/assets/a91ff0b1-cd51-46fc-851f-7c69afbd7ebb)

### Invalid API Key Error (when user is not found or wasn't able to decode the token)
![image](https://github.com/user-attachments/assets/81d1c1ac-ff7f-406a-ad9b-0b1e29a83522)
